### PR TITLE
Proposed Code of Conduct from Citizen CoC

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,62 @@
+# Code of Conduct
+
+## 0. Summary
+
+As participants in this project, we commit to act respectfully to each other.
+
+## 1. Purpose
+
+We are committed to providing a friendly, safe and welcoming environment for all, regardless of gender, sexual orientation, ability, ethnicity, socioeconomic status, and religion (or lack thereof).
+
+This code of conduct outlines our expectations for all those who participate in our community, as well as the consequences for unacceptable behavior.
+
+We invite all those who participate in this project to help us create safe and positive experiences for everyone.
+
+## 3. Expected Behavior
+
+The following behaviors are expected and requested of all community members:
+
+* Participate in an authentic and active way. In doing so, you contribute to the health and longevity of this community.  
+* Exercise consideration and respect in your speech and actions.  
+* Attempt collaboration before conflict.  
+* Refrain from demeaning, discriminatory, or harassing behavior and speech.  
+* Be mindful of your surroundings and of your fellow participants. Alert community leaders if you notice a dangerous situation, someone in distress, or violations of this Code of Conduct, even if they seem inconsequential.  
+* Remember that community event venues may be shared with members of the public; please be respectful to all patrons of these locations.
+
+## 4. Unacceptable Behavior
+
+The following behaviors are considered harassment and are unacceptable within our community:
+
+* Violence, threats of violence or violent language directed against another person.  
+* Sexist, racist, homophobic, transphobic, ableist or otherwise discriminatory jokes and language.  
+* Posting or displaying sexually explicit or violent material.  
+* Posting or threatening to post other people’s personally identifying information ("doxing").  
+* Personal insults, particularly those related to gender, sexual orientation, race, religion, or disability.  
+* Inappropriate photography or recording.  
+* Inappropriate physical contact. You should have someone’s consent before touching them.  
+* Unwelcome sexual attention. This includes, sexualized comments or jokes; inappropriate touching, groping, and unwelcomed sexual advances.  
+* Deliberate intimidation, stalking or following (online or in person).  
+* Advocating for, or encouraging, any of the above behavior.  
+* Sustained disruption of community events, including talks and presentations.
+
+## 6. Consequences of Unacceptable Behavior
+
+Unacceptable behavior from any community member, including sponsors and those with decision-making authority, will not be tolerated.
+
+Anyone asked to stop unacceptable behavior is expected to comply immediately.
+
+If a community member engages in unacceptable behavior, the community organizers may take any action they deem appropriate, up to and including a temporary ban or permanent expulsion from the community without warning (and without refund in the case of a paid event).
+
+## 7. Reporting Guidelines
+
+If you are subject to or witness unacceptable behavior, or have any other concerns, please notify a community organizer as soon as possible.
+
+## 9. Scope
+
+We expect all community participants (contributors, paid or otherwise; sponsors; and other guests) to abide by this Code of Conduct in all community venues–online and in-person–as well as in all one-on-one communications pertaining to community business.
+
+## 11. History and attribution
+
+| Version | Date     | Notes |
+| :------ | :------- | :---- |
+| 1.0     | Sep 2025 | Derived and trimmed from the [Citizen Code of Conduct](https://web.archive.org/web/20200330154000/http://citizencodeofconduct.org/), to match our project’s initial maturity and capacity. |


### PR DESCRIPTION
This pull request is for a light Code of Conduct, derived (and trimmed) from the Citizen Code of Conduct.
It is deliberately not as heavy as the more commonly used https://www.contributor-covenant.org/version/3/0/code_of_conduct/ . 
The heavier CoC locks in a significant commitment to investigate and follow through on CoC complaints as they arise. At our early stage, when we haven't provided volunteers with any training around handling CoC incidents, I don't think we are ready to back up such a commitment, and suggest they be introduced later.