### PR TITLE
#60 Fix gdal version problem for Ubuntu in pyproject.toml

### DIFF
--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -5,10 +5,10 @@ description = "Tools to estimate solar potential for New Zealand"
 readme = "README.md"
 requires-python = ">=3.12" # Ubuntu LTS 24.04 doesn't support 3.13
 dependencies = [
-    "gdal>=3.11.4",
     "h5netcdf>=1.7.3",
     "rioxarray>=0.20.0",
     "gdal==3.11.4", # For Ubuntu LTS 24.04, need to lock to this version, and not go to 3.12
+    #"gdal>=3.11.4",
     "scipy>=1.16.2",
     "xarray>=2025.10.1",
 ]


### PR DESCRIPTION
Fixes https://github.com/rewiring-nz/solar-estimates/issues/60
There is a version dependency problem re-introduced in the last updates to main branch.