### PR TITLE
fix: comma-separate CSV output

### DIFF
--- a/src/utils/stats.py
+++ b/src/utils/stats.py
@@ -229,6 +229,7 @@ def _export_combined_stats(
             columns=columns,
             where="roof_sum IS NOT NULL",
             file=f"{str(output_dir)}/{area}_building_stats.csv",
+            separator=",",
             overwrite=True,
         )
         v_db_select.run()


### PR DESCRIPTION
[The default separator in GRASS is the pipe character](https://grass.osgeo.org/grass-stable/manuals/v.db.select.html), changing it to a comma so it can be imported easily into things.